### PR TITLE
Agent should handle non-numeric PINs more gracefully

### DIFF
--- a/agent.c
+++ b/agent.c
@@ -587,9 +587,13 @@ valid_pin(const char *pin)
 		return (0);
 	}
 	for (i = 0; pin[i] != 0; ++i) {
-		if (!(pin[i] >= '0' && pin[i] <= '9')) {
+		if (!(pin[i] >= '0' && pin[i] <= '9') &&
+		    !(pin[i] >= 'a' && pin[i] <= 'z') &&
+		    !(pin[i] >= 'A' && pin[i] <= 'Z')) {
+			char val[2] = {pin[i], '\0'};
+
 			bunyan_log(WARN, "invalid PIN: contains invalid "
-			    "characters", "pin", BNY_STRING, pin, NULL);
+			    "characters", "inval_char", BNY_STRING, val, NULL);
 			return (0);
 		}
 	}


### PR DESCRIPTION
On at least my Yubikey, the PIN is allowed to be alphanumeric.  It would be nice if the agent supported that.  Additionally, if someone makes a typo when entering their PIN, it would be nice if the resulting output didn't include what is likely their PIN with one error.