### PR TITLE
Fix potential overflow issue

### DIFF
--- a/ebox.c
+++ b/ebox.c
@@ -1324,6 +1324,7 @@ sshbuf_get_ebox_stream(struct sshbuf *buf, struct ebox_stream **pes)
 	errf_t *err;
 	const struct sshcipher *cipher;
 	int dgalg;
+	uint64_t chunklen;
 
 	err = sshbuf_get_ebox(buf, &e);
 	if (err)
@@ -1343,10 +1344,16 @@ sshbuf_get_ebox_stream(struct sshbuf *buf, struct ebox_stream **pes)
 	es->es_ebox = e;
 	e = NULL;
 
-	if ((rc = sshbuf_get_u64(buf, &es->es_chunklen))) {
+	if ((rc = sshbuf_get_u64(buf, &chunklen))) {
 		err = boxderrf(ssherrf("sshbuf_get_u64", rc));
 		goto out;
 	}
+	if (chunklen > SIZE_MAX) {
+		err = errf("OverflowError", NULL,
+		    "buffer size (%llu) is too large", chunklen);
+		goto out;
+	}
+	es->es_chunklen = chunklen;
 
 	if ((rc = sshbuf_get_cstring8(buf, &es->es_cipher, NULL)) ||
 	    (rc = sshbuf_get_cstring8(buf, &es->es_mac, NULL))) {


### PR DESCRIPTION
On OS X Mojave, clang warns because `size_t *` is `unsigned long *` while `uint64_t *` is `unsigned long long *`, and in general there's a potential bug for 32-bit binaries.  A simple fix. 