### PR TITLE
AES key algorithm support for admin key

### DIFF
--- a/piv.c
+++ b/piv.c
@@ -1969,7 +1969,7 @@ invdata:
  * see [piv] 800-73-4 part 2 appendix A.1
  */
 errf_t *
-piv_auth_admin(struct piv_token *pt, const uint8_t *key, size_t keylen)
+piv_auth_admin(struct piv_token *pt, const uint8_t *key, size_t keylen, size_t keyalg)
 {
 	errf_t *err;
 	int rv;
@@ -1983,7 +1983,23 @@ piv_auth_admin(struct piv_token *pt, const uint8_t *key, size_t keylen)
 
 	VERIFY(pt->pt_intxn == B_TRUE);
 
-	cipher = cipher_by_name("3des-cbc");
+	switch (keyalg) {
+		case PIV_ALG_3DES:
+			cipher = cipher_by_name("3des-cbc");
+			break;
+		case PIV_ALG_AES128:
+			cipher = cipher_by_name("aes128-cbc");
+			break;
+		case PIV_ALG_AES256:
+			cipher = cipher_by_name("aes256-cbc");
+			break;
+		case PIV_ALG_AES192:
+			cipher = cipher_by_name("aes192-cbc");
+			break;
+		default:
+			return argerrf("key", "a supported key algorithm", "%u", keyalg);
+	}
+
 	VERIFY(cipher != NULL);
 	VERIFY(cipher_authlen(cipher) == 0);
 	if (cipher_keylen(cipher) != keylen) {
@@ -2001,7 +2017,7 @@ piv_auth_admin(struct piv_token *pt, const uint8_t *key, size_t keylen)
 	tlv_pop(tlv);
 	tlv_pop(tlv);
 
-	apdu = piv_apdu_make(CLA_ISO, INS_GEN_AUTH, PIV_ALG_3DES,
+	apdu = piv_apdu_make(CLA_ISO, INS_GEN_AUTH, keyalg,
 	    PIV_SLOT_ADMIN);
 	apdu->a_cmd.b_data = tlv_buf(tlv);
 	apdu->a_cmd.b_len = tlv_len(tlv);
@@ -2099,7 +2115,7 @@ piv_auth_admin(struct piv_token *pt, const uint8_t *key, size_t keylen)
 
 	pt->pt_reset = B_TRUE;
 
-	apdu = piv_apdu_make(CLA_ISO, INS_GEN_AUTH, PIV_ALG_3DES,
+	apdu = piv_apdu_make(CLA_ISO, INS_GEN_AUTH, keyalg,
 	    PIV_SLOT_ADMIN);
 	apdu->a_cmd.b_data = tlv_buf(tlv);
 	apdu->a_cmd.b_len = tlv_len(tlv);

--- a/piv.h
+++ b/piv.h
@@ -493,7 +493,7 @@ errf_t *piv_read_all_certs(struct piv_token *tk);
  *  - APDUError: the card rejected the command
  */
 MUST_CHECK
-errf_t *piv_auth_admin(struct piv_token *tk, const uint8_t *key, size_t keylen);
+errf_t *piv_auth_admin(struct piv_token *tk, const uint8_t *key, size_t keylen, size_t keyalg);
 
 /*
  * YubicoPIV-specific: changes the 3DES card administrator key.

--- a/pivy-tool.c
+++ b/pivy-tool.c
@@ -1003,8 +1003,8 @@ again:
 		err = errfno("getpass", errno, "");
 		return (err);
 	}
-	if (strlen(p) < 6 || strlen(p) > 8) {
-		warnx("PIN must be 6-8 %s", charType);
+	if (strlen(p) < 4 || strlen(p) > 8) {
+		warnx("PIN must be 4-8 %s", charType);
 		goto again;
 	}
 	newpin = strdup(p);
@@ -1070,8 +1070,8 @@ again:
 		err = errfno("getpass", errno, "");
 		return (err);
 	}
-	if (strlen(p) < 6 || strlen(p) > 8) {
-		warnx("PIN must be 6-8 %s", charType);
+	if (strlen(p) < 4 || strlen(p) > 8) {
+		warnx("PIN must be 4-8 %s", charType);
 		goto again;
 	}
 	newpin = strdup(p);

--- a/pivy-tool.c
+++ b/pivy-tool.c
@@ -81,6 +81,7 @@ static const uint8_t DEFAULT_ADMIN_KEY[] = {
 	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
 };
 #define DEFAULT_KEY_LENGTH 24
 static const uint8_t *admin_key = DEFAULT_ADMIN_KEY;
@@ -332,11 +333,11 @@ assert_pin(struct piv_token *pk, struct piv_slot *slot, boolean_t prompt)
 		} else if (pin == NULL) {
 			piv_txn_end(pk);
 			err(EXIT_PIN, "failed to read PIN");
-		} else if (strlen(pin) < 6 || strlen(pin) > 8) {
+		} else if (strlen(pin) < 4 || strlen(pin) > 8) {
 			const char *charType = "digits";
 			if (piv_token_is_ykpiv(selk))
 				charType = "characters";
-			errx(EXIT_PIN, "a valid PIN must be 6-8 %s in length",
+			errx(EXIT_PIN, "a valid PIN must be 4-8 %s in length",
 			    charType);
 		}
 		pin = strdup(pin);


### PR DESCRIPTION
I have an Gemalto IDPrime PIV Card2.0 using an AES-128 admin key. I had to patch this tool and could run a `pivy-tool init -l 16 -A aes128` and generates keys after this. Also this card is using just a 4 digit PIN. Please check if this is all what is needed to enable AES support.