### PR TITLE
Display Ed255/X255 instead of ? for alg codes 0x22/0x23

### DIFF
--- a/piv.h
+++ b/piv.h
@@ -167,6 +167,12 @@ enum piv_alg {
 	PIV_ALG_ECCP384 = 0x14,
 
 	/*
+	 * Proprietary extension for SoloKeys PIV.
+	 */
+	PIV_ALG_ED25519 = 0x22,
+	PIV_ALG_X25519 = 0x23,
+
+	/*
 	 * Proprietary hack for Javacards running PivApplet -- they don't
 	 * support bare ECDSA so instead we have to give them the full input
 	 * data and they hash it on the card.

--- a/pivy-tool.c
+++ b/pivy-tool.c
@@ -408,6 +408,10 @@ alg_to_string(uint alg)
 		return ("ECCP256");
 	case PIV_ALG_ECCP384:
 		return ("ECCP384");
+	case PIV_ALG_ED25519:
+		return ("Ed25519");
+	case PIV_ALG_X25519:
+		return ("X25519");
 	case PIV_ALG_ECCP256_SHA1:
 		return ("ECCP256-SHA1");
 	case PIV_ALG_ECCP256_SHA256:


### PR DESCRIPTION
Precedent:
https://github.com/solokeys/piv-authenticator/blob/edac42a7ad35fa4ce9c6eac639fdf66a292452b1/src/piv_types.rs#L65-L75  
https://github.com/go-piv/piv-go/commit/e6548dd11f020eb8a3922086893dee86537b47ce