### PR TITLE
piv: parse deprecated chuid value

### DIFF
--- a/piv.c
+++ b/piv.c
@@ -7384,6 +7384,9 @@ piv_chuid_decode(const uint8_t *data, size_t len, struct piv_chuid **out)
 				goto out;
 			chuid->pc_flags |= PIV_CHUID_HAS_CHUUID;
 			break;
+		case 0x3D:	/* Authentication Key Map (Deprecated) */
+			tlv_skip(tlv);
+			break;
 		case 0x3E:	/* Issuer Signature */
 			err = tlv_read_alloc(tlv, &d, &dlen);
 			if (err)


### PR DESCRIPTION
Authentication Key Map is deprecated and no longer present in the recent PIV Nist spec. Older tokens seem to still contain it sometimes. So just parse & skip it instead of aborting because of an unrecognized tag.

See #36 