### PR TITLE
fix: remove invalid algorithm

### DIFF
--- a/pivy-tool.c
+++ b/pivy-tool.c
@@ -2813,7 +2813,7 @@ usage(void)
 	    "Options for 'generate'/'req-cert':\n"
 	    "  -a <algo>              Choose algorithm of new key\n"
 	    "                         EC algos: eccp256, eccp384\n"
-	    "                         RSA algos: rsa1024, rsa2048, rsa4096\n"
+	    "                         RSA algos: rsa1024, rsa2048\n"
 	    "  -n <cn>                Set a CN= attribute to be used on\n"
 	    "                         the new slot's certificate\n"
 	    "  -u <upn>               Set a UPN= attribute to be used on\n"


### PR DESCRIPTION
RSA4096 seems no longer supported.

```
$ pivy-tool -a rsa4096 -i once generate 9a
pivy-tool: failed to parse -a
  Caused by InvalidAlgorithm: Invalid/unknown algorithm name: 'rsa4096'
    in piv_alg_from_string() at piv.c:5932
```

It is not listed on `piv_alg_from_string` function:
https://github.com/arekinath/pivy/blob/4fbe5beb2642d80c14d3b3109ef2a2ccd8cb4169/piv.c#L6007-L6044