### PR TITLE
Update openssh to 9.5p1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: pivy-tool pivy-agent pivy-box
 LIBRESSL_VER	= 3.7.0
 LIBRESSL_URL	= https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$(LIBRESSL_VER).tar.gz
 
-OPENSSH_VER	= 9.2p1
+OPENSSH_VER	= 9.5p1
 OPENSSH_URL	= https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$(OPENSSH_VER).tar.gz
 
 OPENSSH		= $(CURDIR)/openssh


### PR DESCRIPTION
Since the release of zlib 1.3, old versions of the "buggy zlib" check have begun failing due to the lack of patch number (1.3.x).  In openssh 9.5p1, this check was updated to handle zlib versions which are only comprised of major/minor numbers.