### PR TITLE
piv: ignore InvalidDataError when reading all certs.

### DIFF
--- a/piv.c
+++ b/piv.c
@@ -4102,7 +4102,8 @@ read_all_aborts_on(errf_t *err)
 	return (err &&
 	    !errf_caused_by(err, "NotFoundError") &&
 	    !errf_caused_by(err, "PermissionError") &&
-	    !errf_caused_by(err, "NotSupportedError"));
+	    !errf_caused_by(err, "NotSupportedError") &&
+	    !errf_caused_by(err, "InvalidDataError"));
 }
 
 errf_t *

--- a/pivy-agent.c
+++ b/pivy-agent.c
@@ -1293,7 +1293,8 @@ process_request_identities(socket_entry_t *e)
 
 	n = 0;
 	while ((slot = piv_slot_next(selk, slot)) != NULL) {
-		if (!is_slot_enabled(slot))
+		if (!is_slot_enabled(slot) ||
+                    piv_slot_pubkey(slot) == NULL)
 			continue;
 		++n;
 	}
@@ -1303,7 +1304,8 @@ process_request_identities(socket_entry_t *e)
 		fatal("%s: buffer error: %s", __func__, ssh_err(r));
 
 	while ((slot = piv_slot_next(selk, slot)) != NULL) {
-		if (piv_slot_id(slot) == PIV_SLOT_KEY_MGMT)
+		if (piv_slot_id(slot) == PIV_SLOT_KEY_MGMT ||
+                    piv_slot_pubkey(slot) == NULL)
 			continue;
 		if (!is_slot_enabled(slot))
 			continue;
@@ -1322,7 +1324,7 @@ process_request_identities(socket_entry_t *e)
 	 * to try using it.
 	 */
 	if ((slot = piv_get_slot(selk, PIV_SLOT_KEY_MGMT)) != NULL &&
-	    is_slot_enabled(slot)) {
+	    is_slot_enabled(slot) && piv_slot_pubkey(slot) != NULL) {
 		comment[0] = 0;
 		snprintf(comment, sizeof (comment), "PIV_slot_%02X %s",
 		    piv_slot_id(slot), piv_slot_subject(slot));


### PR DESCRIPTION
The version of libressl/openssh in use now is more strict about parsing certificates than prior versions. This may cause `pivy-tool list` and other tasks that need to iterate over card contents to be unable to list any certificates on a card with one bad certificate. Changing `read_all` to _not_ abort on `InvalidDataError` allows using other certs on the card, and also makes it clear which cert is the problem.

A similar change is needed for `pivy-agent` so as not to crash in the presence of a bad cert.

Closes #57 